### PR TITLE
Feature - Added on paid event

### DIFF
--- a/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
+++ b/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
@@ -145,11 +145,11 @@ private static class BackgroundThreadFactory implements ThreadFactory
 							RunnerJNILib.CreateAsynEventWithDSMap(dsMapIndex, EVENT_OTHER_SOCIAL);
 
 							// Initialize ad types using extension options
-							AdMob_Banner_Init(RunnerJNILib.extOptGetString("AdMob", "Android_BANNER"));
-							AdMob_Interstitial_Init(RunnerJNILib.extOptGetString("AdMob", "Android_INTERSTITIAL"));
-							AdMob_RewardedVideo_Init(RunnerJNILib.extOptGetString("AdMob", "Android_REWARDED"));
-							AdMob_RewardedInterstitial_Init(RunnerJNILib.extOptGetString("AdMob", "Android_REWARDED_INTERSTITIAL"));
-							AdMob_AppOpenAd_Init(RunnerJNILib.extOptGetString("AdMob", "Android_OPENAPPAD"));
+							AdMob_Banner_Init((bannerID == "") ? RunnerJNILib.extOptGetString("AdMob", "Android_BANNER") : bannerID);
+							AdMob_Interstitial_Init((mInterstitialID == "") ? RunnerJNILib.extOptGetString("AdMob", "Android_INTERSTITIAL") : mInterstitialID);
+							AdMob_RewardedVideo_Init((mRewardedAdID == "") ? RunnerJNILib.extOptGetString("AdMob", "Android_REWARDED") : mRewardedAdID);
+							AdMob_RewardedInterstitial_Init((mRewardedInterstitialAdID == "") ? RunnerJNILib.extOptGetString("AdMob", "Android_REWARDED_INTERSTITIAL") : mRewardedInterstitialAdID);
+							AdMob_AppOpenAd_Init((mAppOpenAdID == "") ? RunnerJNILib.extOptGetString("AdMob", "Android_OPENAPPAD") : mAppOpenAdID);
 							
 							init_success = true;
 						}


### PR DESCRIPTION
I added the "paid event" logic so that the value of each printout can be sent to firebase. It sends an asynchronous event to GM with the information, ideally this should be integrated in every native admob "ad_impression".
( DOC: https://developers.google.com/admob/android/impression-level-ad-revenue )

![image](https://github.com/YoYoGames/GMEXT-AdMob/assets/14205306/b4836595-375c-4bb6-b431-58e331db914a)
![image](https://github.com/YoYoGames/GMEXT-AdMob/assets/14205306/299808b1-5ed4-4df2-82a2-199041e92535)
