### PR TITLE
Fixed ad micros not returning.

### DIFF
--- a/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
+++ b/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
@@ -1785,7 +1785,10 @@ public class GoogleMobileAdsGM extends RunnerSocial {
         data.put("mediation_adapter_class_name", mediationAdapterClassName);
         data.put("unit_id", adUnitId);
         data.put("ad_type", adType);
-        data.put("micros", adValue.getValueMicros());
+
+        Long adMicros = adValue.getValueMicros();
+        data.put("micros", (double) adMicros);
+        
         data.put("currency_code", adValue.getCurrencyCode());
         data.put("precision", (double) adValue.getPrecisionType());
 


### PR DESCRIPTION
adValue.getValueMicros() returns a Long value.

The current sendAsyncEvent function cannot detect a Long input. There's no need to implement that in the function as there's no other Long variable present in the extension. Only a small edit on the onPaidEventHandler function is sufficient.