### PR TITLE
Updated App Open Ad implementation to invoke during the correct Android lifecycle event.

### DIFF
--- a/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
+++ b/source/AdMob_gml/extensions/admob/AndroidSource/Java/GoogleMobileAdsGM.java
@@ -1665,10 +1665,10 @@ public class GoogleMobileAdsGM extends RunnerSocial {
 	}
 
 	@Override
-    public void onResume() {
-		super.onResume();
+    public void onStart() {
+		super.onStart();
         if (triggerAppOpenAd && !isShowingAd) {
-            if (!appOpenAdIsValid("onResume")) {
+            if (!appOpenAdIsValid("onStart")) {
                 AdMob_AppOpenAd_Load();
                 return;
             }


### PR DESCRIPTION
This was previously in the onResume event.

Even the slightest UI disruption would trigger the App Open Ad (such as starting an in-app purchase flow or simply displaying an interstitial ad). This shouldn’t have been the default behavior and doesn’t match the behavior on iOS.

The onStart event is the correct one, as it ensures the App Open Ad is invoked only when the app returns from the background. This change follows Google’s own examples, which also use onStart for this purpose.

- https://github.com/googleads/googleads-mobile-android-examples/blob/516f36eaca33b7acc70cb6646cbad51070c8bdce/java/admob/AppOpenExample/app/src/main/java/com/google/android/gms/example/appopenexample/MyApplication.java#L61-L67
- https://developers.google.com/admob/android/app-open
